### PR TITLE
Updated Documents to Reflect "From Ashes"

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,31 @@
 
-This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+Arctic Zephyr is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
 To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/3.0/
 or send a letter to Creative Commons, 171 Second Street, Suite 300, San Francisco, California, 94105, USA.
+
+As of Arctic Zephyr 3 ("From Ashes"), the license is also available on the Arctic Zephyr Homepage.
+To view a copy of this license and additional information, visit https://northebridge.com/systems/oss/arcticzephyr
+or contact NortheBridge(R) directly at https://northebridge.com/support 
+
+Arctic Zephyr is free and open source software designed to work with Kodi and Emby Server. You may do the following:
+
+Share — copy and redistribute the material in any medium or format
+Adapt — remix, transform, and build upon the material
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+Under the following terms:
+
+Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. 
+You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+Non-Commercial — You may not use the material for commercial purposes.
+
+Share Alike — If you remix, transform, or build upon the material, you must distribute your contributions under 
+the same license as the original.
+
+Notices:
+
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, 
+or moral rights may limit how you use the material.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+[B]3.0.0[/B]
+Initial Release of "From Ashes"
+New Audio Navigation Package
+New About Page (Accessible from Settings)
+Fixed Time Meridian in Media Information Screen
+Additional Color Selections
+Splash Screen Updated with "From Ashes"
+
 [B]1.2.5[/B]
 pvrosdguide to fixed list show current at top
 Fix osd streaming info


### PR DESCRIPTION
Changes to the Changelog and the License to reflect "From Ashes" rather
than generic Arctic Zephyr. Changelog hasn't been updated since version
1.2.5 - skips to version 3.0.0.
